### PR TITLE
add special actions for Variant Dungeons

### DIFF
--- a/Definitions/Variant.json
+++ b/Definitions/Variant.json
@@ -1,0 +1,12 @@
+{
+"job": "variant",
+"actions" : [
+    { "7421" : "variant cure", "heal": [ { "potency": 0} ] }
+],
+"statuseffects" : [
+    { "d27" : "rehabilitation", "timeproc": { "type": "hot", "potency": 4200, "maxticks": 5 } },
+    { "d1f" : "sustained damage", "timeproc": { "type": "dot", "potency": 2040, "maxticks": 10 } },
+    { "d4d" : "damage barrier", "damageshield": { "type": "Potency", "amount": 21000 } },
+    { "d20" : "vulnerability down", "potency": [ { "type": "DamageReceivedMultiplier", "amount": -20 } ] }
+]
+}


### PR DESCRIPTION
Adds special actions for Variant Dungeons.  Tooltips are as follows:

Variant Cure (spell)
Restores target's HP.
Cure Potency: 14,000
Additional Effect: Regen (status: Rehabilitation)
Cure Potency: 4,200
Duration: 15s
Additional Effect: Cure potency is doubled when target is under the effect of Rehabilitation
This action is not affected by attributes.

Variant Spirit Dart (ability)
Deals damage over time to target and all enemies nearby it.
Potency: 2,040 (status: Sustained Damage)
Duration: 30s
This action is not affected by attributes or enhancing effects.

Variant Rampart (ability)
Reduces damage taken by 20%. (status: Vulnerability Down)
Duration: 60s
Creates a barrier around self that absorbs damage equivalent to a heal of 21,000 potency. (status: Damage Barrier)